### PR TITLE
support cuda<10, cudaStreamAddCallback replace cudaLaunchHostFunc

### DIFF
--- a/src/mem/allocator/cuda_dual_allocator.cc
+++ b/src/mem/allocator/cuda_dual_allocator.cc
@@ -26,7 +26,11 @@ static void free_caller() {
 
 }
 
+#if CUDA_VERSION < 10000
+void to_free_allocation(cudaStream_t stream, cudaError_t status, void*) {
+#else
 void to_free_allocation(void*) {
+#endif
     using namespace cuda_dual_local;
     event_queue.push(free_caller);
 }

--- a/src/mem/allocator/cuda_dual_allocator.h
+++ b/src/mem/allocator/cuda_dual_allocator.h
@@ -79,7 +79,11 @@ extern list<Allocation> allocations;
 
 }
 
+#if CUDA_VERSION < 10000
+void to_free_allocation(cudaStream_t stream, cudaError_t status, void*);
+#else
 void to_free_allocation(void*);
+#endif
 
 struct DelayFree final : Allocator {
     inline uint64 flags() const override { return _cuda; };
@@ -94,7 +98,11 @@ struct DelayFree final : Allocator {
     void free(void* mem_ptr, size_t size, const size_t& allocation) override {
         using namespace cuda_dual_local;
         allocations.emplace_back(mem_ptr, allocation, size, &cuda_dual_allocator);
+#if CUDA_VERSION < 10000
+        checkCudaErrors(cudaStreamAddCallback(0, &to_free_allocation, 0, 0));
+#else
         checkCudaErrors(cudaLaunchHostFunc(0, &to_free_allocation, 0));
+#endif
     }
 
     void migrate_to_cpu(void*& mem_ptr, size_t& allocation, size_t size, Allocator* allocator) {


### PR DESCRIPTION
support <=CUDA10, check if `CUDA_VERSION` is less than 10, call `cudaStreamAddCallback` instead of `cudaLaunchHostFunc`, I tried on ubuntu16.04/gcc5.4/cuda9.0, it works
refer to related links: https://github.com/NVIDIA/TensorRT/issues/221