### PR TITLE
fixed bug: print(model) crashed when there is a no-default-init-param layer, such as Tanh, Sigmoid or a empty Sequential.

### DIFF
--- a/python/jittor/__init__.py
+++ b/python/jittor/__init__.py
@@ -506,6 +506,8 @@ class Module:
         return cd
 
     def extra_repr(self):
+        if self.__init__.__defaults__ is None:
+            return ""
         ss = []
         n = len(self.__init__.__code__.co_varnames) - \
             len(self.__init__.__defaults__)


### PR DESCRIPTION
Fixed bug:
* print(model) crashed when there is a no-default-init-param layer, such as Tanh, Sigmoid or a empty Sequential.