### PR TITLE
Update BatchNorm1d

### DIFF
--- a/python/jittor/nn.py
+++ b/python/jittor/nn.py
@@ -371,7 +371,7 @@ class BatchNorm(Module):
         return norm_x * w + b
         
 class BatchNorm1d(Module):
-    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=None, is_train=True, sync=True):
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True, is_train=True, sync=True):
         self.sync = sync
         self.num_features = num_features
         self.is_train = is_train


### PR DESCRIPTION
Change default value of affine in BatchNorm1d to be True.

In early implementation, the default behavior of BatchNorm1d is to use affine transform.

```python
class BatchNorm1d(Module):
    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=None, is_train=True, sync=True):
        assert affine == None
        self.sync = sync
        self.num_features = num_features
        self.is_train = is_train
        self.eps = eps
        self.momentum = momentum
        self.weight = init.constant((num_features,), "float32", 1.0)
        self.bias = init.constant((num_features,), "float32", 0.0)
        self.running_mean = init.constant((num_features,), "float32", 0.0).stop_grad()
        self.running_var = init.constant((num_features,), "float32", 1.0).stop_grad()
```

After commit 8d64d98a356ebe7b825d9a0e0bb18d0ce30678e8, BatchNorm1d does not use affine transform by default. This leads to failures in some earlier scripts (for example, `gan-jittor/modules/began/began.py`). 
