### PR TITLE
fallback to find nvcc in PATH

### DIFF
--- a/python/jittor/compiler.py
+++ b/python/jittor/compiler.py
@@ -866,10 +866,7 @@ ex_python_path = python_path + '.' + str(sys.version_info.minor)
 if os.path.isfile(ex_python_path):
     python_path = ex_python_path
 py3_config_path = jit_utils.py3_config_path
-
-nvcc_path = env_or_try_find('nvcc_path', '/usr/local/cuda/bin/nvcc')
-if not nvcc_path:
-    nvcc_path = env_or_try_find('nvcc_path', '/usr/bin/nvcc')
+nvcc_path = env_or_try_find('nvcc_path', 'nvcc') or try_find_exe('/usr/local/cuda/bin/nvcc') or try_find_exe('/usr/bin/nvcc')
 gdb_path = try_find_exe('gdb')
 addr2line_path = try_find_exe('addr2line')
 has_pybt = check_pybt(gdb_path, python_path)


### PR DESCRIPTION
感觉从`PATH`中搜索`nvcc`更自然些，如我的服务器上没有`/usr/local/cuda/bin/nvcc`或`/usr/bin/nvcc`，cuda安装目录如下
```
ls /usr/local/* | grep cuda
/usr/local/cuda-10.0:
/usr/local/cuda-10.2:
/usr/local/cuda-11.1:
/usr/local/cuda-8.0:
/usr/local/cuda-9.0:
```
通过环境变量定义使用的cuda版本
```
export CUDA_HOME=/usr/local/cuda-10.0
export LD_LIBRARY_PATH=$CUDA_HOME/lib64 # Use CUDA 10.0 to support TitanXp
export PATH=$CUDA_HOME/bin:$PATH
```