### PR TITLE
fix one bug in win11 jittor\src\misc\cpu_math.cc(47): error C2065: 'M…

### DIFF
--- a/python/jittor/src/misc/cpu_math.cc
+++ b/python/jittor/src/misc/cpu_math.cc
@@ -4,6 +4,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 // ***************************************************************
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>
 #include "misc/cpu_math.h"


### PR DESCRIPTION
系统：Win11
环境：python3.8
框架：jittor:1.3.1.15
执行该命令：python -m jittor.test.test_core或者运行教程一的测试代码
出现以下问题：
[e 1030 00:30:46.463000 84 log.cc:526] cpu_math.cc
E:\anaconda3\envs\jittor\lib\site-packages\jittor\src\misc\cpu_math.cc(47): error C2065: 'M_PI': undeclared identifier
E:\anaconda3\envs\jittor\lib\site-packages\jittor\src\misc\cpu_math.cc(53): note: see reference to function template instantiation 'float jittor::calc_erfinv<float>(T)' being compiled
        with
        [
            T=float
        ]
E:\anaconda3\envs\jittor\lib\site-packages\jittor\src\misc\cpu_math.cc(48): error C2065: 'M_PI': undeclared identifier
