### PR TITLE
Allow for nn.Sequential to be sliced.

### DIFF
--- a/python/jittor/nn.py
+++ b/python/jittor/nn.py
@@ -2037,7 +2037,7 @@ class Sequential(Module):
             else:
                 self.append(mod)
     def __getitem__(self, idx):
-        if idx not in self.layers:
+        if isinstance(idx, slice) or idx not in self.layers:
             return list(self.layers.values())[idx]
 
         return self.layers[idx]


### PR DESCRIPTION
Allows you to use slices to index into `nn.Sequential`,  for example:

```
model = nn.Sequential(...)  # add stuff here
for layer in model[1:]:  # Previously this would have raised  "TypeError: unhashable type: 'slice"
    pass
```