### PR TITLE
Fix Jittor Utils Config Bugs

### DIFF
--- a/python/jittor/test/__init__.py
+++ b/python/jittor/test/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+
+# ***************************************************************
+# Copyright (c) 2022 Jittor. All Rights Reserved. 
+# Maintainers: Dun Liang <randonlang@gmail.com>. 
+# This file is subject to the terms and conditions defined in
+# file 'LICENSE.txt', which is part of this source code package.
+# ***************************************************************

--- a/python/jittor/utils/__init__.py
+++ b/python/jittor/utils/__init__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+# ***************************************************************
+# Copyright (c) 2022 Jittor. All Rights Reserved. 
+# Maintainers: 
+#     Guowei Yang <471184555@qq.com>
+#     Dun Liang <randonlang@gmail.com>. 
+# 
+# This file is subject to the terms and conditions defined in
+# file 'LICENSE.txt', which is part of this source code package.
+# ***************************************************************

--- a/python/jittor_utils/config.py
+++ b/python/jittor_utils/config.py
@@ -13,7 +13,7 @@ def search_file(dirs, name):
     LOG.f(f"file {name} not found in {dirs}")
 
 if __name__ == "__main__":
-    help_msg = f"Usage: {sys.executable} -m jittor_utils.config --include-flags|--link-flags|--cxx-flags|--cxx-example|--help"
+    help_msg = f"Usage: {sys.executable} -m jittor_utils.config --include-flags|--libs-flags|--cxx-flags|--cxx-example|--help"
     if len(sys.argv) <= 1:
         print(help_msg)
         sys.exit(1)
@@ -38,7 +38,10 @@ if __name__ == "__main__":
             for libbase in libpaths:
                 libpath = os.path.join(libbase, f"lib{base}.{libext}")
                 if os.path.isfile(libpath):
-                    s += f" -L{libbase} -l{base} -ldl "
+                    if os.name == "posix":
+                        s += f" -Wl,-rpath={libbase} -L{libbase} -l{base} -ldl "
+                    else:
+                        s += f" -L{libbase} -l{base} -ldl "
                     break
             else:
                 raise RuntimeError("Python dynamic library not found")


### PR DESCRIPTION
## 1. Two Bugs for 'Jittor Utils Config':
1) **Bug 1**: Command option for 'python -m jittor_utils.config' 
```$ python -m jittor_utils.config```
Usage: /home/dell/miniconda3/envs/numba/bin/python -m jittor_utils.config --include-flags|**--link-flags**|--cxx-flags|--cxx-example|--help

**Expected:**
Usage: /home/dell/miniconda3/envs/numba/bin/python -m jittor_utils.config --include-flags|**--libs-flags**|--cxx-flags|--cxx-example|--help

2) **Bug 2**: example could not find libpython3.10.so.1.0
```
$  python -m jittor_utils.config --cxx-example > example.cc
$　g++ example.cc $(python -m jittor_utils.config --include-flags --libs-flags --cxx-flags) -o example
$ ./example
```

./example: **error** while loading shared libraries: libpython3.10.so.1.0: cannot open shared object file: No such file or directory
$ ldd example
	linux-vdso.so.1 (0x00007fff99cb2000)
	**libpython3.10.so.1.0 => not found**
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2732a25000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f2732843000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f2732828000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2732636000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2732a59000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f27324e7000)

## 2. Fixed Results
1) **Bug 1:**
```$ python -m jittor_utils.config```
Usage: /home/dell/miniconda3/envs/numba/bin/python -m jittor_utils.config --include-flags|**--libs-flags**|--cxx-flags|--cxx-example|--help

2) **Bug 2:**
```$ python -m jittor_utils.config --libs-flags```
 **-Wl,-rpath=/home/dell/miniconda3/envs/numba/lib** -L/home/dell/miniconda3/envs/numba/lib -lpython3.10 -ldl 
```
$ python -m jittor_utils.config --cxx-example > example.cc
$ g++ example.cc $(python -m jittor_utils.config --include-flags --libs-flags --cxx-flags) -o example
$ ./example
```
...
pred.shape 2 1000

```$ ldd example```
	linux-vdso.so.1 (0x00007ffdd2c92000)
	**libpython3.10.so.1.0 => /home/dell/miniconda3/envs/numba/lib/libpython3.10.so.1.0 (0x00007ff04eeb6000)**
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ff04ee95000)
	libstdc++.so.6 => /home/dell/miniconda3/envs/numba/lib/libstdc++.so.6 (0x00007ff04ec81000)
	libgcc_s.so.1 => /home/dell/miniconda3/envs/numba/lib/libgcc_s.so.1 (0x00007ff04ec67000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff04ea75000)
	libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007ff04ea70000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ff04e91f000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff04e8fc000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff04f295000)
