### PR TITLE
support build triu/tril of an inf matrix

### DIFF
--- a/python/jittor/__init__.py
+++ b/python/jittor/__init__.py
@@ -9,7 +9,7 @@
 # file 'LICENSE.txt', which is part of this source code package.
 # ***************************************************************
 
-__version__ = '1.3.6.12'
+__version__ = '1.3.6.13'
 from jittor_utils import lock
 with lock.lock_scope():
     ori_int = int

--- a/python/jittor/misc.py
+++ b/python/jittor/misc.py
@@ -2013,7 +2013,7 @@ def triu(input: jt.Var, diagonal:int=0) -> jt.Var:
     '''
     index = input.index()
     mask = index[-2] <= index[-1] - diagonal
-    return input*mask
+    return jt.ternary(mask, input, jt.zeros_like(input))
 jt.Var.triu = triu
 
 def tril(input: jt.Var, diagonal:int=0) -> jt.Var:
@@ -2037,7 +2037,7 @@ def tril(input: jt.Var, diagonal:int=0) -> jt.Var:
     '''
     index = input.index()
     mask = index[-2] >= index[-1] - diagonal
-    return input*mask
+    return jt.ternary(mask, input, jt.zeros_like(input))
 jt.Var.tril = tril
 
 def all_equal(a: jt.Var, b: jt.Var) -> bool:


### PR DESCRIPTION
The original implementation results in nan because zeros * inf = nan. 

Suggest to use jt.ternary op instead of multiply a mask matrix.