### PR TITLE
Fix getpid not found

### DIFF
--- a/python/jittor/src/mem/swap.cc
+++ b/python/jittor/src/mem/swap.cc
@@ -11,6 +11,7 @@
 #endif
 #include <stdio.h>
 #include <thread>
+#include <unistd.h>
 #include "var.h"
 #include "mem/swap.h"
 #include "mem/mem_info.h"


### PR DESCRIPTION
/usr/local/lib/python3.7/site-packages/jittor/src/mem/swap.cc:24:19: error: ‘getpid’ was not declared in this scope
 static int _pid = getpid();
                   ^~~~~~
/usr/local/lib/python3.7/site-packages/jittor/src/mem/swap.cc:24:19: note: suggested alternative: ‘get_tid’
 static int _pid = getpid();
                   ^~~~~~
                   get_tid