### PR TITLE
fix issue 531,530;update jt.nn.PixelShuffle/jt.histc

### DIFF
--- a/python/jittor/misc.py
+++ b/python/jittor/misc.py
@@ -2171,6 +2171,8 @@ def histc(input, bins, min=0., max=0.):
     if min == 0 and max == 0:
         min, max = input.min(), input.max()
     assert min < max
+    if bins <= 0:
+        raise RuntimeError(f"bins must be > 0, but got {bins}")
     bin_length = (max - min) / bins
     histc = jt.floor((input[jt.logical_and(input >= min, input <= max)] - min) / bin_length).int().reshape(-1)
     hist = jt.ones_like(histc).float().reindex_reduce("add", [bins,], ["@e0(i0)"], extras=[histc])

--- a/python/jittor/nn.py
+++ b/python/jittor/nn.py
@@ -1766,6 +1766,8 @@ class PixelShuffle(Module):
         n,c,h,w = x.shape
         r = self.upscale_factor
         assert c%(r*r)==0, f"input channel needs to be divided by upscale_factor's square in PixelShuffle"
+        if r<0:
+            raise RuntimeError(f"pixel_shuffle expects a positive upscale_factor, but got {r}")
         return x.reindex([n,int(c/r**2),h*r,w*r], [
             "i0",
             f"i1*{r*r}+i2%{r}*{r}+i3%{r}",


### PR DESCRIPTION
Add runtime error when the upscale_factor of jt.nn.PixelShuffle is a negative value.
Add runtime error when the bin parameter of jt.histc is a non-positive value.