### PR TITLE
fix issue 529;update contrib.argmax_pool()

### DIFF
--- a/python/jittor/contrib.py
+++ b/python/jittor/contrib.py
@@ -15,6 +15,8 @@ from collections.abc import Sequence
 
 
 def argmax_pool(x, size, stride, padding=0):
+    if stride<0:
+        raise RuntimeError(f"stride must be > 0, but got {stride}")
     return pool.pool(x, size, 'maximum', padding, stride)
 
 def concat(arr, dim):

--- a/python/jittor/contrib.py
+++ b/python/jittor/contrib.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 
 
 def argmax_pool(x, size, stride, padding=0):
-    if stride<0:
+    if stride<=0:
         raise RuntimeError(f"stride must be > 0, but got {stride}")
     return pool.pool(x, size, 'maximum', padding, stride)
 


### PR DESCRIPTION
Add runtime error when the stride parameter of jt.contrib.argmax_pool() is non-positive.