### PR TITLE
fix unqualified call to 'std::move'

### DIFF
--- a/python/jittor/src/misc/cstr.h
+++ b/python/jittor/src/misc/cstr.h
@@ -27,7 +27,7 @@ struct cstr {
         return *this;
     }
     inline cstr& operator=(cstr&& s) {
-        ptr = move(s.ptr);
+        ptr = std::move(s.ptr);
         return *this;
     }
     inline cstr& operator=(const cstr& s) {

--- a/python/jittor/src/opt/expr.h
+++ b/python/jittor/src/opt/expr.h
@@ -157,11 +157,11 @@ template<class... Args>
 unique_ptr<Expr> make_op(const string& str, Args&&... args) {
     vector<unique_ptr<Expr>> children;
     children.reserve(sizeof...(args));
-    auto f = [&](unique_ptr<Expr>& c) { children.emplace_back(move(c)); };
+    auto f = [&](unique_ptr<Expr>& c) { children.emplace_back(std::move(c)); };
     // Brace-enclosed initializers
     int dummy[] = {(f(args), 0)...};
     (void)dummy;
-    return make(str, move(children));
+    return make(str, std::move(children));
 }
 
 template <typename Func>

--- a/python/jittor/src/utils/log.h
+++ b/python/jittor/src/utils/log.h
@@ -135,7 +135,7 @@ struct Log {
     inline void end() {
         if (g_supports_color) out << color_end;
         out << '\n';
-        send_log(move(out), level, verbose);
+        send_log(std::move(out), level, verbose);
     }
     inline void flush() { flush_log(); }
 


### PR DESCRIPTION
fix warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]