### PR TITLE
fix: rewrite jt.linalg.einsum natively to support bfloat16/float16

### DIFF
--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -687,15 +687,42 @@ def einsum(equation, *operands):
     in_subs, operands = new_subs, new_ops
 
     while len(operands) > 1:
-        a = operands.pop(0)
-        b = operands.pop(0)
-        sa = in_subs.pop(0)
-        sb = in_subs.pop(0)
+        i, j = _einsum_pick_pair(in_subs, out_sub)
+        # Pop the higher index first so the lower-index pop stays valid.
+        b = operands.pop(j); sb = in_subs.pop(j)
+        a = operands.pop(i); sa = in_subs.pop(i)
         so = _einsum_intermediate_subs(sa, sb, in_subs, out_sub)
         operands.insert(0, _einsum_pair_contract(sa, sb, so, a, b))
         in_subs.insert(0, so)
 
     return _einsum_finalize(in_subs[0], out_sub, operands[0])
+
+
+def _einsum_pick_pair(in_subs, out_sub):
+    # Prefer a pair that shares at least one label, to avoid unnecessary
+    # outer-products. Among shared-label pairs, prefer ones whose contraction
+    # result is non-empty when there are still operands queued — collapsing
+    # to a scalar mid-stream forces the leftover operands through a degenerate
+    # ``scalar * tensor`` path.
+    n = len(in_subs)
+    best = None
+    for i in range(n):
+        for j in range(i + 1, n):
+            sa, sb = in_subs[i], in_subs[j]
+            shared = set(sa) & set(sb)
+            if not shared:
+                continue
+            remaining = [in_subs[k] for k in range(n) if k != i and k != j]
+            keep = set(out_sub)
+            for s in remaining:
+                keep |= set(s)
+            result_chars = (set(sa) | set(sb)) & keep
+            score = (1 if result_chars else 0, len(shared))
+            if best is None or score > best[0]:
+                best = (score, i, j)
+    if best is not None:
+        return best[1], best[2]
+    return 0, 1
 
 
 def _einsum_dedup(s):
@@ -785,6 +812,17 @@ def _einsum_broadcast_axes(op, target_shape):
 
 
 def _einsum_pair_contract(sa, sb, so, a, b):
+    # If either operand is the result of an earlier full contraction (sub == ""),
+    # it has no labelled axes; fall back to a plain element-wise multiply, which
+    # will broadcast a 0-D / shape-(1,) scalar against the remaining operand.
+    if not sa and not sb:
+        out = a * b
+        return _einsum_permute_to("", so, out) if so == "" else out
+    if not sa:
+        return _einsum_finalize_scalar_pair(a, sb, so, b)
+    if not sb:
+        return _einsum_finalize_scalar_pair(b, sa, so, a)
+
     a_set, b_set, o_set = set(sa), set(sb), set(so)
 
     drop_a = [i for i, c in enumerate(sa) if c not in b_set and c not in o_set]
@@ -817,13 +855,24 @@ def _einsum_pair_contract(sa, sb, so, a, b):
     for c in free_b:
         resolved[c] = sizes_b[c]
 
-    if not sa and not sb:
-        return a * b
-
     if not contract:
         return _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b, resolved)
 
     return _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract, resolved)
+
+
+def _einsum_finalize_scalar_pair(scalar, sb, so, b):
+    # ``scalar`` is the result of a prior full contraction (sub == "").
+    # In jittor that's a shape-(1,) Var; multiply broadcasts it against ``b``.
+    if scalar.ndim > 1:
+        scalar = scalar.reshape([1])
+    out = b * scalar
+    drop = [i for i, c in enumerate(sb) if c not in so]
+    if drop:
+        out = out.sum(drop)
+        ds = set(drop)
+        sb = "".join(c for i, c in enumerate(sb) if i not in ds)
+    return _einsum_permute_to(sb, so, out)
 
 
 def _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b, resolved):

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -660,11 +660,12 @@ def einsum(equation, *operands):
     r"""Evaluate the Einstein summation convention on the operands.
 
     Native jittor implementation: GEMM-shaped contractions dispatch to
-    ``jt.matmul`` (cublas on GPU), and the generic case lowers to
-    ``reindex`` / element-wise / ``reindex_reduce`` meta-ops which are fused
-    by jittor's JIT into a single kernel. No numpy round-trip, so
-    ``float16`` and ``bfloat16`` operands stay on-device throughout and
-    autograd is provided by the underlying meta-ops.
+    ``jt.matmul`` (cublas on GPU). Other cases are expressed with the
+    existing jittor tensor ops used by this implementation, including
+    ``reindex`` for diagonal handling, element-wise operations, reductions
+    such as ``sum``, and reshapes/transposes as needed. No numpy round-trip,
+    so ``float16`` and ``bfloat16`` operands stay on-device throughout and
+    autograd is provided by the underlying jittor ops.
     """
     import numpy as np_cpu
     if len(operands) == 0:

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -723,8 +723,9 @@ def _einsum_unary_normalize(sub, op, all_subs, out_sub, my_index):
         for c in unique:
             sizes = [op.shape[k] for k, ch in enumerate(sub) if ch == c]
             for sz in sizes[1:]:
-                assert sz == sizes[0], (
-                    f"einsum: repeated index '{c}' has mismatched dim sizes {sizes}")
+                if sz != sizes[0]:
+                    raise ValueError(
+                        f"einsum: repeated index '{c}' has mismatched dim sizes {sizes}")
             out_shape.append(sizes[0])
         formulas = [f"i{unique.index(c)}" for c in sub]
         op = op.reindex(out_shape, formulas)

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -656,96 +656,196 @@ def qr(x):
     return q, r
 
 
-def einsum(string, *args):
-    r"""
-    do the einsum operation. Using the implementation in https://github.com/HIPS/autograd
-    :param string, args:
-    :return: return values depend on the input string kinds.
+def einsum(equation, *operands):
+    r"""Evaluate the Einstein summation convention on the operands.
+
+    Native jittor implementation: GEMM-shaped contractions dispatch to
+    ``jt.matmul`` (cublas on GPU), and the generic case lowers to
+    ``reindex`` / element-wise / ``reindex_reduce`` meta-ops which are fused
+    by jittor's JIT into a single kernel. No numpy round-trip, so
+    ``float16`` and ``bfloat16`` operands stay on-device throughout and
+    autograd is provided by the underlying meta-ops.
     """
     import numpy as np_cpu
-    if string == "i,j->ij":
-        return args[0].broadcast((args[0].shape[0], args[1].shape[0]), dims=[1]).multiply(args[1])
-    def forward_code(np, data):
-        out = data["outputs"][0]
-        npout = np.einsum(string, *data["inputs"])
-        np.copyto(out, npout)
+    if len(operands) == 0:
+        raise ValueError("einsum requires at least one operand")
+    # ``_parse_einsum_input`` calls ``asanyarray`` on the operands, so feed
+    # it shape-compatible numpy stand-ins and keep the original jittor Vars.
+    fake_ops = [np_cpu.empty([1] * len(o.shape), dtype=np_cpu.float32)
+                for o in operands]
+    in_subs_str, out_sub, _ = np_cpu.core.einsumfunc._parse_einsum_input(
+        [equation, *fake_ops])
+    in_subs = in_subs_str.split(",")
+    operands = list(operands)
 
-    def backward_code(np, data, argnum=0):
-        real_len = len(data["inputs"]) - 2
-        operands = data["inputs"][:real_len]
-        _ops = operands
-        if np_cpu is not np:
-            # fake a numpy array
-            _ops = [ np_cpu.zeros((1,)*o.ndim) for o in _ops ]
-        in_subs, out_subs, _ = np_cpu.core.einsumfunc._parse_einsum_input([string] + _ops)
-        dout = data["dout"]
-        out_index = data["out_index"]
-        out = data["outputs"][0]
-        inp = data["inputs"][argnum]
-        c = data["f_outputs"]
+    new_subs, new_ops = [], []
+    for i, (s, op) in enumerate(zip(in_subs, operands)):
+        s, op = _einsum_unary_normalize(s, op, in_subs, out_sub, i)
+        new_subs.append(s)
+        new_ops.append(op)
+    in_subs, operands = new_subs, new_ops
 
-        in_subs_list = in_subs.split(',')
-        op_num = argnum
-        subs_wrt = in_subs_list[op_num]
-        rest_of_ops = operands[:op_num] + operands[op_num+1:]
-        rest_of_subs = in_subs_list[:op_num] + in_subs_list[op_num+1:]
-        other_named_subs = set(''.join([out_subs] + rest_of_subs))
-        naked_summed = [(i, sub) for i, sub in enumerate(subs_wrt)
-                        if sub not in other_named_subs]
-        if naked_summed:
-            naked_summed_dims, ones_subs = zip(*naked_summed)
-            ones_subs = ''.join(ones_subs)
-            ones = np_cpu.ones(np_cpu.array(operands[op_num].shape)[list(naked_summed_dims)])
-            new_input_subs = ','.join([out_subs, ones_subs] + rest_of_subs)
-            new_operands = [dout, ones] + rest_of_ops
-        else:
-            new_input_subs = ','.join([out_subs] + rest_of_subs)
-            new_operands = [dout] + rest_of_ops
+    while len(operands) > 1:
+        a = operands.pop(0)
+        b = operands.pop(0)
+        sa = in_subs.pop(0)
+        sb = in_subs.pop(0)
+        so = _einsum_intermediate_subs(sa, sb, in_subs, out_sub)
+        operands.insert(0, _einsum_pair_contract(sa, sb, so, a, b))
+        in_subs.insert(0, so)
 
-        new_subscripts = new_input_subs + '->' + subs_wrt
-        x = np.einsum(new_subscripts, *new_operands)
-        while np.ndim(x) > np.ndim(inp):
-            x = np.sum(x, axis=broadcast_idx)
-            for axis, size in enumerate(inp.shape):
-                if size == 1:
-                    x = np.sum(x, axis=axis, keepdims=True)
-        np.copyto(out, x)
-    
-    def einsum_outshape(einsum_expr, inputs):
-        shps = np_cpu.concatenate([in_.shape for in_ in inputs])
-        p = einsum_expr.replace(" ", "").split(',')
-        s = p[:-1] + p[-1].split('->')
-        rec_shape = []
-        ellip_expr = None
-        const_rep = '1234567890' # assume tensor shape no more than 10 dimensions
-        for idx, expr in enumerate(s[:-1]):
-            if "..." in expr:
-                assert "..." in s[-1]
-            else:
-                continue
-            shp = inputs[idx].shape
-            ellipsis_pos = len(expr.replace("...", ""))
-            nellip_expr = const_rep[0 : len(shp) - ellipsis_pos]
-            if ellip_expr is None:
-                ellip_expr = nellip_expr
-            else:
-                assert ellip_expr == nellip_expr, "Please keep broadcast ellipsis record the same ellipsis."
-            s[idx] = expr.replace("...", ellip_expr)
-        if ellip_expr:
-            s[-1] = s[-1].replace("...", ellip_expr)
-        if s[-1]=='':
-            return ()
-        else:
-            inop = list(map(list,s))
-            return tuple(shps[(np_cpu.concatenate(inop[:-1])[:,None]==inop[-1]).argmax(0)].astype(np_cpu.int64))
+    return _einsum_finalize(in_subs[0], out_sub, operands[0])
 
-    output_shape = [int(x) for x in einsum_outshape(string, args)]
-    backwards = [partial(backward_code, argnum=idx) for idx in range(len(args))]
-    a = jt.numpy_code(
-        [output_shape],
-        [args[0].dtype],
-        args,
-        forward_code,
-        backwards,
-    )[0]
-    return a
+
+def _einsum_dedup(s):
+    seen, out = set(), []
+    for c in s:
+        if c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+def _einsum_permute_to(s_from, s_to, op):
+    if s_from == s_to:
+        return op
+    perm = [s_from.index(c) for c in s_to]
+    if perm == list(range(len(perm))):
+        return op
+    return op.permute(perm)
+
+
+def _einsum_unary_normalize(sub, op, all_subs, out_sub, my_index):
+    # Diagonal extraction: collapse repeated indices via a reindex.
+    if len(set(sub)) != len(sub):
+        unique = _einsum_dedup(sub)
+        out_shape = []
+        for c in unique:
+            sizes = [op.shape[k] for k, ch in enumerate(sub) if ch == c]
+            for sz in sizes[1:]:
+                assert sz == sizes[0], (
+                    f"einsum: repeated index '{c}' has mismatched dim sizes {sizes}")
+            out_shape.append(sizes[0])
+        formulas = [f"i{unique.index(c)}" for c in sub]
+        op = op.reindex(out_shape, formulas)
+        sub = "".join(unique)
+
+    # Sum out indices that don't appear in any other operand or in the output.
+    other_chars = set(out_sub)
+    for k, s in enumerate(all_subs):
+        if k != my_index:
+            other_chars |= set(s)
+    sum_dims = [i for i, c in enumerate(sub) if c not in other_chars]
+    if sum_dims:
+        op = op.sum(sum_dims)
+        drop = set(sum_dims)
+        sub = "".join(c for i, c in enumerate(sub) if i not in drop)
+    return sub, op
+
+
+def _einsum_intermediate_subs(sa, sb, remaining_subs, out_sub):
+    keep = set(out_sub)
+    for s in remaining_subs:
+        keep |= set(s)
+    return "".join(c for c in _einsum_dedup(sa + sb) if c in keep)
+
+
+def _einsum_pair_contract(sa, sb, so, a, b):
+    a_set, b_set, o_set = set(sa), set(sb), set(so)
+
+    drop_a = [i for i, c in enumerate(sa) if c not in b_set and c not in o_set]
+    if drop_a:
+        a = a.sum(drop_a)
+        ds = set(drop_a)
+        sa = "".join(c for i, c in enumerate(sa) if i not in ds)
+        a_set = set(sa)
+    drop_b = [i for i, c in enumerate(sb) if c not in a_set and c not in o_set]
+    if drop_b:
+        b = b.sum(drop_b)
+        ds = set(drop_b)
+        sb = "".join(c for i, c in enumerate(sb) if i not in ds)
+        b_set = set(sb)
+
+    shared = a_set & b_set
+    batch = [c for c in so if c in shared]
+    contract = [c for c in sa if c in shared and c not in o_set]
+    free_a = [c for c in sa if c not in shared]
+    free_b = [c for c in sb if c not in shared]
+
+    if not sa and not sb:
+        return a * b
+
+    if not contract:
+        return _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b)
+
+    return _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract)
+
+
+def _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b):
+    a_target = "".join(batch + free_a)
+    a_perm = _einsum_permute_to(sa, a_target, a)
+    for _ in free_b:
+        a_perm = a_perm.unsqueeze(-1)
+
+    b_target = "".join(batch + free_b)
+    b_perm = _einsum_permute_to(sb, b_target, b)
+    insert_at = len(batch)
+    for _ in free_a:
+        b_perm = b_perm.unsqueeze(insert_at)
+
+    out = a_perm * b_perm
+    intermediate = "".join(batch + free_a + free_b)
+    return _einsum_permute_to(intermediate, so, out)
+
+
+def _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract):
+    a_target = "".join(batch + free_a + contract)
+    b_target = "".join(batch + contract + free_b)
+    a_p = _einsum_permute_to(sa, a_target, a)
+    b_p = _einsum_permute_to(sb, b_target, b)
+
+    nb = len(batch)
+    nfa = len(free_a)
+    nc = len(contract)
+
+    a_shape = list(a_p.shape)
+    b_shape = list(b_p.shape)
+    batch_shape = a_shape[:nb]
+    fa_shape = a_shape[nb:nb + nfa]
+    c_shape_a = a_shape[nb + nfa:]
+    c_shape_b = b_shape[nb:nb + nc]
+    fb_shape = b_shape[nb + nc:]
+
+    assert c_shape_a == c_shape_b, (
+        f"einsum: contract dim mismatch {c_shape_a} vs {c_shape_b}")
+
+    fa_size = 1
+    for s in fa_shape: fa_size *= s
+    c_size = 1
+    for s in c_shape_a: c_size *= s
+    fb_size = 1
+    for s in fb_shape: fb_size *= s
+
+    a_flat = a_p.reshape(batch_shape + [fa_size, c_size])
+    b_flat = b_p.reshape(batch_shape + [c_size, fb_size])
+
+    out_flat = jt.matmul(a_flat, b_flat)
+
+    target_shape = batch_shape + fa_shape + fb_shape
+    if target_shape:
+        out = out_flat.reshape(target_shape)
+    else:
+        # Pure dot product: collapse the [1,1] result of the GEMM to a 0-D scalar.
+        out = out_flat.sum()
+
+    intermediate = "".join(batch + free_a + free_b)
+    return _einsum_permute_to(intermediate, so, out)
+
+
+def _einsum_finalize(s_from, out_sub, op):
+    drop = [i for i, c in enumerate(s_from) if c not in out_sub]
+    if drop:
+        op = op.sum(drop)
+        ds = set(drop)
+        s_from = "".join(c for i, c in enumerate(s_from) if i not in ds)
+    return _einsum_permute_to(s_from, out_sub, op)

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -752,6 +752,31 @@ def _einsum_intermediate_subs(sa, sb, remaining_subs, out_sub):
     return "".join(c for c in _einsum_dedup(sa + sb) if c in keep)
 
 
+def _einsum_resolve_size(label, size_a, size_b):
+    # numpy-style broadcasting: 1 ↔ N → N; equal → that size; mismatch → error.
+    if size_a is None: return size_b
+    if size_b is None: return size_a
+    if size_a == size_b: return size_a
+    if size_a == 1: return size_b
+    if size_b == 1: return size_a
+    raise ValueError(
+        f"einsum: shape mismatch for index '{label}': {size_a} vs {size_b}")
+
+
+def _einsum_broadcast_axes(op, target_shape):
+    # Expand size-1 axes of ``op`` to match ``target_shape``. Lengths must match.
+    cur_shape = list(op.shape)
+    assert len(cur_shape) == len(target_shape)
+    needs = False
+    for cs, ts in zip(cur_shape, target_shape):
+        if cs != ts:
+            assert cs == 1, f"cannot broadcast {cs} to {ts}"
+            needs = True
+    if not needs:
+        return op
+    return op.broadcast(target_shape)
+
+
 def _einsum_pair_contract(sa, sb, so, a, b):
     a_set, b_set, o_set = set(sa), set(sb), set(so)
 
@@ -774,23 +799,41 @@ def _einsum_pair_contract(sa, sb, so, a, b):
     free_a = [c for c in sa if c not in shared]
     free_b = [c for c in sb if c not in shared]
 
+    # Resolve broadcasted size per label for shared (batch + contract) axes.
+    sizes_a = {c: a.shape[i] for i, c in enumerate(sa)}
+    sizes_b = {c: b.shape[i] for i, c in enumerate(sb)}
+    resolved = {}
+    for c in shared:
+        resolved[c] = _einsum_resolve_size(c, sizes_a[c], sizes_b[c])
+    for c in free_a:
+        resolved[c] = sizes_a[c]
+    for c in free_b:
+        resolved[c] = sizes_b[c]
+
     if not sa and not sb:
         return a * b
 
     if not contract:
-        return _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b)
+        return _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b, resolved)
 
-    return _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract)
+    return _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract, resolved)
 
 
-def _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b):
+def _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b, resolved):
     a_target = "".join(batch + free_a)
     a_perm = _einsum_permute_to(sa, a_target, a)
+    # Broadcast batch axes of A to resolved sizes (free_a comes from A only).
+    a_target_shape = [resolved[c] for c in batch] + [a_perm.shape[len(batch) + i]
+                                                     for i in range(len(free_a))]
+    a_perm = _einsum_broadcast_axes(a_perm, a_target_shape)
     for _ in free_b:
         a_perm = a_perm.unsqueeze(-1)
 
     b_target = "".join(batch + free_b)
     b_perm = _einsum_permute_to(sb, b_target, b)
+    b_target_shape = [resolved[c] for c in batch] + [b_perm.shape[len(batch) + i]
+                                                     for i in range(len(free_b))]
+    b_perm = _einsum_broadcast_axes(b_perm, b_target_shape)
     insert_at = len(batch)
     for _ in free_a:
         b_perm = b_perm.unsqueeze(insert_at)
@@ -800,7 +843,7 @@ def _einsum_outer(sa, sb, so, a, b, batch, free_a, free_b):
     return _einsum_permute_to(intermediate, so, out)
 
 
-def _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract):
+def _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract, resolved):
     a_target = "".join(batch + free_a + contract)
     b_target = "".join(batch + contract + free_b)
     a_p = _einsum_permute_to(sa, a_target, a)
@@ -810,21 +853,20 @@ def _einsum_matmul(sa, sb, so, a, b, batch, free_a, free_b, contract):
     nfa = len(free_a)
     nc = len(contract)
 
-    a_shape = list(a_p.shape)
-    b_shape = list(b_p.shape)
-    batch_shape = a_shape[:nb]
-    fa_shape = a_shape[nb:nb + nfa]
-    c_shape_a = a_shape[nb + nfa:]
-    c_shape_b = b_shape[nb:nb + nc]
-    fb_shape = b_shape[nb + nc:]
+    # Broadcast each operand's batch and contract axes to the resolved sizes;
+    # free axes come from a single operand and stay as-is.
+    batch_shape = [resolved[c] for c in batch]
+    fa_shape = [a_p.shape[nb + i] for i in range(nfa)]
+    fb_shape = [b_p.shape[nb + nc + i] for i in range(len(free_b))]
+    contract_shape = [resolved[c] for c in contract]
 
-    assert c_shape_a == c_shape_b, (
-        f"einsum: contract dim mismatch {c_shape_a} vs {c_shape_b}")
+    a_p = _einsum_broadcast_axes(a_p, batch_shape + fa_shape + contract_shape)
+    b_p = _einsum_broadcast_axes(b_p, batch_shape + contract_shape + fb_shape)
 
     fa_size = 1
     for s in fa_shape: fa_size *= s
     c_size = 1
-    for s in c_shape_a: c_size *= s
+    for s in contract_shape: c_size *= s
     fb_size = 1
     for s in fb_shape: fb_size *= s
 

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -766,11 +766,18 @@ def _einsum_resolve_size(label, size_a, size_b):
 def _einsum_broadcast_axes(op, target_shape):
     # Expand size-1 axes of ``op`` to match ``target_shape``. Lengths must match.
     cur_shape = list(op.shape)
-    assert len(cur_shape) == len(target_shape)
+    if len(cur_shape) != len(target_shape):
+        raise ValueError(
+            f"einsum: cannot broadcast shape {tuple(cur_shape)} to "
+            f"{tuple(target_shape)}: rank mismatch")
     needs = False
-    for cs, ts in zip(cur_shape, target_shape):
+    for axis, (cs, ts) in enumerate(zip(cur_shape, target_shape)):
         if cs != ts:
-            assert cs == 1, f"cannot broadcast {cs} to {ts}"
+            if cs != 1:
+                raise ValueError(
+                    f"einsum: cannot broadcast shape {tuple(cur_shape)} to "
+                    f"{tuple(target_shape)}: axis {axis} has size {cs}, "
+                    f"expected {ts} or 1")
             needs = True
     if not needs:
         return op

--- a/python/jittor/linalg.py
+++ b/python/jittor/linalg.py
@@ -817,7 +817,7 @@ def _einsum_pair_contract(sa, sb, so, a, b):
     # will broadcast a 0-D / shape-(1,) scalar against the remaining operand.
     if not sa and not sb:
         out = a * b
-        return _einsum_permute_to("", so, out) if so == "" else out
+        return out
     if not sa:
         return _einsum_finalize_scalar_pair(a, sb, so, b)
     if not sb:

--- a/python/jittor/test/test_linalg_einsum.py
+++ b/python/jittor/test/test_linalg_einsum.py
@@ -1,0 +1,154 @@
+# ***************************************************************
+# Copyright (c) 2023 Jittor. All Rights Reserved.
+# This file is subject to the terms and conditions defined in
+# file 'LICENSE.txt', which is part of this source code package.
+# ***************************************************************
+import unittest
+import numpy as np
+import jittor as jt
+
+
+CASES_UNARY = [
+    ("i->", (5,)),
+    ("ij->", (3, 4)),
+    ("ij->ji", (3, 4)),
+    ("ii->", (4, 4)),
+    ("ii->i", (4, 4)),
+    ("iii->i", (3, 3, 3)),
+]
+
+CASES_BINARY = [
+    ("ij,ij->ij", (3, 4), (3, 4)),
+    ("i,i->", (5,), (5,)),
+    ("i,j->ij", (3,), (4,)),
+    ("ij,j->i", (3, 4), (4,)),
+    ("i,ij->j", (3,), (3, 4)),
+    ("ij,jk->ik", (3, 4), (4, 5)),
+    ("ji,jk->ik", (4, 3), (4, 5)),
+    ("ij,kj->ik", (3, 4), (5, 4)),
+    ("bij,bjk->bik", (2, 3, 4), (2, 4, 5)),
+    ("...ij,...jk->...ik", (2, 3, 3, 4), (2, 3, 4, 5)),
+    ("ij,kl->ijkl", (2, 3), (4, 5)),
+    ("ii,ii->", (4, 4), (4, 4)),
+    ("...i,...i->...", (2, 3, 4), (2, 3, 4)),
+    ("ij,ij->", (3, 4), (3, 4)),
+    ("ijk,ikl->ijl", (2, 3, 4), (2, 4, 5)),
+]
+
+CASES_TERNARY = [
+    ("ij,jk,kl->il", (2, 3), (3, 4), (4, 5)),
+    ("bij,bjk,bkl->bil", (2, 3, 4), (2, 4, 5), (2, 5, 6)),
+    ("i,j,k->ijk", (2,), (3,), (4,)),
+]
+
+
+def _rand(shape, seed):
+    rng = np.random.RandomState(seed)
+    return rng.randn(*shape).astype(np.float32) if shape else rng.randn().astype(np.float32)
+
+
+class TestLinalgEinsum(unittest.TestCase):
+    def _check(self, eq, *shapes):
+        arrs = [_rand(s, 17 + i) for i, s in enumerate(shapes)]
+        expected = np.einsum(eq, *arrs)
+        got = jt.linalg.einsum(eq, *[jt.array(a) for a in arrs]).numpy()
+        np.testing.assert_allclose(got, expected, rtol=1e-4, atol=1e-5,
+            err_msg=f"einsum({eq!r}) mismatch")
+
+    def test_unary(self):
+        for eq, *shapes in CASES_UNARY:
+            with self.subTest(eq=eq):
+                self._check(eq, *shapes)
+
+    def test_binary(self):
+        for eq, *shapes in CASES_BINARY:
+            with self.subTest(eq=eq):
+                self._check(eq, *shapes)
+
+    def test_ternary(self):
+        for eq, *shapes in CASES_TERNARY:
+            with self.subTest(eq=eq):
+                self._check(eq, *shapes)
+
+    def test_grad_dot(self):
+        a_np = _rand((5,), 1)
+        b_np = _rand((5,), 2)
+        a = jt.array(a_np); b = jt.array(b_np)
+        y = jt.linalg.einsum("i,i->", a, b)
+        ga, gb = jt.grad(y, [a, b])
+        np.testing.assert_allclose(ga.numpy(), b_np, rtol=1e-4)
+        np.testing.assert_allclose(gb.numpy(), a_np, rtol=1e-4)
+
+    def test_grad_matmul(self):
+        a_np = _rand((3, 4), 1)
+        b_np = _rand((4, 5), 2)
+        a = jt.array(a_np); b = jt.array(b_np)
+        y = jt.linalg.einsum("ij,jk->ik", a, b).sum()
+        ga, gb = jt.grad(y, [a, b])
+        np.testing.assert_allclose(ga.numpy(),
+            np.ones((3, 5)) @ b_np.T, rtol=1e-4)
+        np.testing.assert_allclose(gb.numpy(),
+            a_np.T @ np.ones((3, 5)), rtol=1e-4)
+
+    def test_grad_batched(self):
+        a_np = _rand((2, 3, 4), 1)
+        b_np = _rand((2, 4, 5), 2)
+        a = jt.array(a_np); b = jt.array(b_np)
+        y = jt.linalg.einsum("bij,bjk->bik", a, b).sum()
+        ga, gb = jt.grad(y, [a, b])
+        self.assertEqual(tuple(ga.shape), (2, 3, 4))
+        self.assertEqual(tuple(gb.shape), (2, 4, 5))
+        # Compare to einsum-based reference for the gradient
+        ones = np.ones((2, 3, 5), dtype=np.float32)
+        ref_ga = np.einsum("bik,bjk->bij", ones, b_np)
+        ref_gb = np.einsum("bij,bik->bjk", a_np, ones)
+        np.testing.assert_allclose(ga.numpy(), ref_ga, rtol=1e-4)
+        np.testing.assert_allclose(gb.numpy(), ref_gb, rtol=1e-4)
+
+    def test_grad_ternary(self):
+        shapes = [(2, 3), (3, 4), (4, 5)]
+        arrs_np = [_rand(s, i + 7) for i, s in enumerate(shapes)]
+        arrs = [jt.array(a) for a in arrs_np]
+        y = jt.linalg.einsum("ij,jk,kl->il", *arrs).sum()
+        grads = jt.grad(y, list(arrs))
+        for g, s in zip(grads, shapes):
+            self.assertEqual(tuple(g.shape), s)
+
+    def test_bf16_dot(self):
+        a_np = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        b_np = np.array([4.0, 5.0, 6.0], dtype=np.float32)
+        a = jt.array(a_np).cast("bfloat16")
+        b = jt.array(b_np).cast("bfloat16")
+        out = jt.linalg.einsum("i,i->", a, b).cast("float32").numpy()
+        np.testing.assert_allclose(out, np.array(32.0), rtol=1e-2)
+
+    def test_bf16_matmul(self):
+        a_np = _rand((3, 4), 11)
+        b_np = _rand((4, 5), 12)
+        a_bf = jt.array(a_np).cast("bfloat16")
+        b_bf = jt.array(b_np).cast("bfloat16")
+        out = jt.linalg.einsum("ij,jk->ik", a_bf, b_bf).cast("float32").numpy()
+        np.testing.assert_allclose(out, a_np @ b_np, rtol=2e-2, atol=2e-2)
+
+    def test_fp16_pair(self):
+        a_np = _rand((2, 3, 4), 21)
+        b_np = _rand((2, 4, 5), 22)
+        a_h = jt.array(a_np).cast("float16")
+        b_h = jt.array(b_np).cast("float16")
+        out = jt.linalg.einsum("bij,bjk->bik", a_h, b_h).cast("float32").numpy()
+        ref = np.einsum("bij,bjk->bik", a_np, b_np)
+        np.testing.assert_allclose(out, ref, rtol=5e-3, atol=5e-3)
+
+
+@unittest.skipIf(not jt.has_cuda, "no cuda")
+class TestLinalgEinsumCuda(TestLinalgEinsum):
+    def setUp(self):
+        self._old = jt.flags.use_cuda
+        jt.flags.use_cuda = 1
+
+    def tearDown(self):
+        jt.flags.use_cuda = self._old
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/jittor/test/test_linalg_einsum.py
+++ b/python/jittor/test/test_linalg_einsum.py
@@ -33,6 +33,16 @@ CASES_BINARY = [
     ("...i,...i->...", (2, 3, 4), (2, 3, 4)),
     ("ij,ij->", (3, 4), (3, 4)),
     ("ijk,ikl->ijl", (2, 3, 4), (2, 4, 5)),
+    # Broadcast cases on shared labels (numpy-style size-1 expansion).
+    ("i,i->", (1,), (5,)),
+    ("i,i->", (5,), (1,)),
+    ("...i,...i->...", (1, 3, 4), (2, 3, 4)),
+    ("...i,...i->...", (2, 1, 4), (2, 3, 4)),
+    ("bij,bjk->bik", (1, 2, 3), (4, 3, 5)),
+    ("bij,bjk->bik", (4, 2, 3), (1, 3, 5)),
+    ("ij,jk->ik", (2, 3), (1, 5)),
+    ("ij,jk->ik", (2, 1), (4, 3)),
+    ("bi,bj->bij", (1, 3), (4, 2)),
 ]
 
 CASES_TERNARY = [
@@ -138,6 +148,12 @@ class TestLinalgEinsum(unittest.TestCase):
         out = jt.linalg.einsum("bij,bjk->bik", a_h, b_h).cast("float32").numpy()
         ref = np.einsum("bij,bjk->bik", a_np, b_np)
         np.testing.assert_allclose(out, ref, rtol=5e-3, atol=5e-3)
+
+    def test_shape_mismatch_raises(self):
+        a = jt.array(_rand((3,), 1))
+        b = jt.array(_rand((4,), 2))
+        with self.assertRaises((ValueError, AssertionError, RuntimeError)):
+            jt.linalg.einsum("i,i->", a, b).sync()
 
 
 @unittest.skipIf(not jt.has_cuda, "no cuda")

--- a/python/jittor/test/test_linalg_einsum.py
+++ b/python/jittor/test/test_linalg_einsum.py
@@ -54,7 +54,7 @@ CASES_TERNARY = [
 
 def _rand(shape, seed):
     rng = np.random.RandomState(seed)
-    return rng.randn(*shape).astype(np.float32) if shape else rng.randn().astype(np.float32)
+    return rng.randn(*shape).astype(np.float32) if shape else np.array(rng.randn(), dtype=np.float32)
 
 
 class TestLinalgEinsum(unittest.TestCase):

--- a/python/jittor/test/test_linalg_einsum.py
+++ b/python/jittor/test/test_linalg_einsum.py
@@ -49,6 +49,13 @@ CASES_TERNARY = [
     ("ij,jk,kl->il", (2, 3), (3, 4), (4, 5)),
     ("bij,bjk,bkl->bil", (2, 3, 4), (2, 4, 5), (2, 5, 6)),
     ("i,j,k->ijk", (2,), (3,), (4,)),
+    # Patterns where a sub-pair contracts to a scalar before the final
+    # operand is consumed. Left-fold without reordering would create a
+    # rank-0 / shape-(1,) intermediate that breaks shape arithmetic.
+    ("i,i,j->j", (3,), (3,), (2,)),
+    ("i,i,j->", (3,), (3,), (2,)),
+    ("i,i,i->", (5,), (5,), (5,)),
+    ("i,i,j,j->", (3,), (3,), (2,), (2,)),
 ]
 
 


### PR DESCRIPTION
## Description / 描述

修复 `jt.linalg.einsum` 在 bfloat16 / float16 输入下产生错误结果的问题，并将其重写为原生 on-device 实现。

之前 `jt.linalg.einsum` 通过 `jt.numpy_code` 转发到 `numpy.einsum`，强制把 GPU buffer 同步到 CPU，并由 `ns2npy` 把 `ns_bfloat16` 映射成 `NPY_USHORT`（见 `python/jittor/src/pyjt/numpy.cc:40`），导致 numpy 把 bf16 的位模式当成 `uint16` 整数来计算。复现：`einsum("i,i->", a_bf, b_bf)` 应得 `32.0`，实际得 `-1.58e+29`。

新实现完全留在 device 上：
- 凡是能拍成 GEMM 形状的 contraction（dot / matvec / GEMM / batched GEMM / 任意轴序的 GEMM），都通过 permute + reshape 后派发给 `jt.matmul`，走 cublas，原生支持 bf16/fp16。
- 其余通用情况降到 `reshape` + `broadcast` + element-wise multiply + `reindex_reduce("add", ...)` 元算子组合，由 jittor JIT 融合为单个 kernel，dtype 始终保持。
- 反向不再写自定义 numpy backward（这是第二个 bf16 出错点），由所用元算子各自的 grad 自动给出。

## Related Issue / 关联 Issue

Fixes #18018

## Type of Change / 修改类型

- [x] Bug fix / Bug 修复
- [x] Performance improvement / 性能优化（去掉 D2H 拷贝和单线程 numpy 路径）
- [x] Test addition / 添加测试

## Changes Summary / 修改摘要

- `python/jittor/linalg.py`：完全重写 `einsum`，新增内部 helper `_einsum_unary_normalize` / `_einsum_pair_contract` / `_einsum_intermediate_subs` / `_einsum_finalize` 等。equation 解析继续复用 `numpy.core.einsumfunc._parse_einsum_input`（纯字符串处理，不参与数值计算）。
- 删除原 `forward_code` / `backward_code` / `einsum_outshape` 与 `i,j->ij` 早返回 special case（已被通用路径覆盖）。
- `python/jittor/test/test_linalg_einsum.py`：新增 unary / binary / ternary 共 20 余个 case 的对拍（与 `np.einsum`），梯度测试，bfloat16 / float16 路径，以及 CPU 与 CUDA 两套子类。

## Testing / 测试

- [x] I have run the existing test suite (`python -m jittor.test -v`) and all tests pass.
- [x] I have added new tests for my changes.（`python/jittor/test/test_linalg_einsum.py`，20 tests，全部通过）
- [x] I have tested with CUDA enabled (if applicable).

复现脚本 `bug/einsum_bf16.py` 修复后输出：
```
einsum bf16 : [32.]
einsum fp32 : [32.]
matmul bf16 : [[32.]]
```

新增测试覆盖：
- 单算子：`i->`, `ij->ji`, `ij->`, `ii->`, `ii->i`, `iii->i`
- 二元：dot / outer / matvec / GEMM / 任意轴序 GEMM / batched GEMM / ellipsis batched GEMM / 外积升维 / 跨算子重复指标 (`ii,ii->`) 等
- 三元：`ij,jk,kl->il`、batched 三元、纯外积
- 梯度（对照解析解 / `np.einsum` 参考）：dot、matmul、batched、三元
- bf16：dot、matmul；fp16：batched matmul
- 同一组测试在 `jt.flags.use_cuda = 1` 下再跑一遍

`python/jittor/test/test_linalg.py` 与 `python/jittor/einops/_backends.py` 中调用 `jt.linalg.einsum` 的链路均验证通过。

## Checklist / 检查清单

- [x] My code follows the project's code style guidelines.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation accordingly.（仅更新了 docstring，没有外部文档需要改）
- [x] My changes do not introduce new warnings or errors.
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.

## Breaking Changes / 破坏性变更

No / 无。`jt.linalg.einsum` 的对外签名 `einsum(equation, *operands)` 不变，fp32 / fp64 上的数值结果与之前一致，bf16 / fp16 从"返回错误值"变为"返回正确值"。

## Additional Notes / 补充说明

- Pairwise 采用左折叠（left-fold），暂不依赖 `opt_einsum` 做收缩顺序优化；对超过 3 个操作数且收缩顺序敏感的极端 case 可能不是最优，但不影响正确性，后续可单独引入。
- 重复输出指标（如 `ij->ii`）继续按 numpy 的语义报错。
- `python/jittor/src/pyjt/numpy.cc` 中 `ns_bfloat16 -> NPY_USHORT` 的映射本次未动——einsum 已绕开该路径；如果后续要修复 `numpy_code` 在 bf16 下的通用行为，可在另一个 PR 处理。