### PR TITLE
Fix Windows MSVC import for packed data

### DIFF
--- a/python/jittor/compiler.py
+++ b/python/jittor/compiler.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import glob
+from jittor_utils import packed_data
 import inspect
 import datetime
 import threading
@@ -1350,19 +1351,48 @@ if use_data_gz:
         with open(data_gz_md5_path, 'r') as f:
             target_md5 = f.read()
     data_o_path = os.path.join(cache_path, "data.o")
-    if target_md5 != md5:
+    windows_patch_md5 = md5
+    if os.name == "nt":
+        windows_patch_md5 = hashlib.md5(
+            (md5 + packed_data.WINDOWS_PACKED_DATA_PATCH_VERSION).encode("utf8")
+        ).hexdigest()
+    if target_md5 != windows_patch_md5:
         data_s_path = os.path.join(cache_path, "data.cc")
-        with open(data_s_path, "w") as f:
-            f.write(data.decode("utf8"))
+        data_src = data.decode("utf8")
         dflags = (cc_flags+opt_flags)\
             .replace("-Wall", "") \
             .replace("-Werror", "") \
             .replace("-shared", "")
-        vdp = os.path.join(jittor_path, "src", "utils", "vdp")
-        run_cmd(fix_cl_flags(f"\"{cc_path}\" {dflags} -include \"{vdp}\" \"{data_s_path}\" -c -o \"{data_o_path}\""))
+        if os.name == "nt":
+            data_raw_path = os.path.join(cache_path, "data_packed.cc")
+            with open(data_raw_path, "w", encoding="utf8") as f:
+                f.write(data_src)
+            vdp = os.path.join(jittor_path, "src", "utils", "vdp")
+            pp_flags = remove_flags(dflags, ["-l", "-L", ".lib"])
+            data_src = run_cmd(
+                fix_cl_flags(
+                    f"\"{cc_path}\" {pp_flags} -include \"{vdp}\" -EP \"{data_raw_path}\""
+                )
+            )
+            data_src = data_src.replace("\r\n", "\n").replace("\r", "\n")
+            data_lines = data_src.splitlines()
+            if data_lines and data_lines[0].strip().lower().endswith(
+                (".c", ".cc", ".cpp", ".cxx")
+            ):
+                data_lines = data_lines[1:]
+            data_src = "\n".join(data_lines)
+            data_src = packed_data.patch_windows_source(data_src)
+            os.remove(data_raw_path)
+        with open(data_s_path, "w", encoding="utf8") as f:
+            f.write(data_src)
+        if os.name == "nt":
+            run_cmd(fix_cl_flags(f"\"{cc_path}\" {dflags} \"{data_s_path}\" -c -o \"{data_o_path}\""))
+        else:
+            vdp = os.path.join(jittor_path, "src", "utils", "vdp")
+            run_cmd(fix_cl_flags(f"\"{cc_path}\" {dflags} -include \"{vdp}\" \"{data_s_path}\" -c -o \"{data_o_path}\""))
         os.remove(data_s_path)
         with open(data_gz_md5_path, 'w') as f:
-            f.write(md5)
+            f.write(windows_patch_md5)
     files.append(data_o_path)
     files = [f for f in files if "__data__" not in f]
 else:

--- a/python/jittor/test/test_windows_packed_data.py
+++ b/python/jittor/test/test_windows_packed_data.py
@@ -1,0 +1,58 @@
+import importlib.util
+import pathlib
+import unittest
+
+_PACKED_DATA_PATH = (
+    pathlib.Path(__file__).resolve().parents[2] / "jittor_utils" / "packed_data.py"
+)
+_PACKED_DATA_SPEC = importlib.util.spec_from_file_location(
+    "jittor_packed_data_test_helper", _PACKED_DATA_PATH
+)
+packed_data = importlib.util.module_from_spec(_PACKED_DATA_SPEC)
+assert _PACKED_DATA_SPEC.loader is not None
+_PACKED_DATA_SPEC.loader.exec_module(packed_data)
+
+
+class TestWindowsPackedData(unittest.TestCase):
+    def test_windows_preprocessed_source_uses_wrappers_for_node_callbacks(self):
+        source = """
+namespace jittor {
+static const char * x8006(void ( * func)(Node * )) {
+    if (func == (void( * )(Node * )) & Node :: release_forward_liveness) return "rf";
+    if (func == (void( * )(Node * )) & Node :: own_pending_liveness) return "op";
+    return "unknown";
+}
+void Node :: free () {
+    x16239 . emplace_back(this, (void( * )(Node * )) & Node :: release_backward_liveness);
+}
+void Node :: own_both_liveness () {
+    x16239 . emplace_back(this, (void( * )(Node * )) & Node :: own_forward_liveness);
+}
+}
+"""
+        patched = packed_data.patch_windows_source(source)
+
+        self.assertIn(
+            "static void _jt_release_forward_liveness(Node* node)",
+            patched,
+        )
+        self.assertIn(
+            "func == _jt_release_forward_liveness",
+            patched,
+        )
+        self.assertIn(
+            "func == _jt_own_pending_liveness",
+            patched,
+        )
+        self.assertIn(
+            "x16239 . emplace_back(this, _jt_release_backward_liveness);",
+            patched,
+        )
+        self.assertIn(
+            "x16239 . emplace_back(this, _jt_own_forward_liveness);",
+            patched,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/jittor_utils/packed_data.py
+++ b/python/jittor_utils/packed_data.py
@@ -1,0 +1,141 @@
+import re
+from functools import lru_cache
+
+
+WINDOWS_PACKED_DATA_PATCH_VERSION = "windows-preprocessed-v1"
+
+
+_WINDOWS_NODE_CALLBACK_WRAPPERS = {
+    "release_forward_liveness": "_jt_release_forward_liveness",
+    "release_backward_liveness": "_jt_release_backward_liveness",
+    "release_pending_liveness": "_jt_release_pending_liveness",
+    "own_forward_liveness": "_jt_own_forward_liveness",
+    "own_backward_liveness": "_jt_own_backward_liveness",
+    "own_pending_liveness": "_jt_own_pending_liveness",
+}
+
+
+def _split_args(src: str):
+    args = []
+    start = 0
+    depth = 0
+    for i, ch in enumerate(src):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            args.append(src[start:i])
+            start = i + 1
+    args.append(src[start:])
+    return args
+
+
+def decode_source(source: str) -> str:
+    char_map = {}
+    kept_lines = []
+    for line in source.splitlines():
+        if line.startswith("#define x"):
+            _, name, value = line.split(" ", 2)
+            char_map[name] = value
+            continue
+        if line.startswith("#define XX") or line.startswith("#define _XX"):
+            continue
+        if line.startswith("_P(") and line.endswith(")"):
+            kept_lines.append(line[3:-1])
+            continue
+        kept_lines.append(line)
+    body = "\n".join(kept_lines)
+
+    @lru_cache(maxsize=None)
+    def decode_expr(expr: str) -> str:
+        out = []
+        i = 0
+        n = len(expr)
+        while i < n:
+            if expr.startswith("_P(", i):
+                depth = 1
+                k = i + 3
+                while k < n and depth:
+                    if expr[k] == "(":
+                        depth += 1
+                    elif expr[k] == ")":
+                        depth -= 1
+                    k += 1
+                if depth == 0:
+                    out.append(decode_expr(expr[i + 3 : k - 1]))
+                    i = k
+                    continue
+            if expr.startswith("XX", i):
+                j = i + 2
+                while j < n and expr[j].isdigit():
+                    j += 1
+                k0 = j
+                while k0 < n and expr[k0].isspace():
+                    k0 += 1
+                if k0 < n and expr[k0] == "(":
+                    depth = 1
+                    k = k0 + 1
+                    while k < n and depth:
+                        if expr[k] == "(":
+                            depth += 1
+                        elif expr[k] == ")":
+                            depth -= 1
+                        k += 1
+                    if depth == 0:
+                        inner = expr[k0 + 1 : k - 1]
+                        out.append(
+                            "".join(decode_expr(arg.strip()) for arg in _split_args(inner))
+                        )
+                        i = k
+                        continue
+            if expr[i] == "x":
+                j = i + 1
+                while j < n and expr[j].isdigit():
+                    j += 1
+                token = expr[i:j]
+                if token in char_map:
+                    out.append(char_map[token])
+                    i = j
+                    continue
+            out.append(expr[i])
+            i += 1
+        return "".join(out)
+
+    return decode_expr(body)
+
+
+def patch_windows_source(source: str) -> str:
+    wrappers = (
+        "\n"
+        "static void _jt_release_forward_liveness(Node* node) { node->release_forward_liveness(); }\n"
+        "static void _jt_release_backward_liveness(Node* node) { node->release_backward_liveness(); }\n"
+        "static void _jt_release_pending_liveness(Node* node) { node->release_pending_liveness(); }\n"
+        "static void _jt_own_forward_liveness(Node* node) { node->own_forward_liveness(); }\n"
+        "static void _jt_own_backward_liveness(Node* node) { node->own_backward_liveness(); }\n"
+        "static void _jt_own_pending_liveness(Node* node) { node->own_pending_liveness(); }\n\n"
+    )
+    pattern = re.compile(
+        r"\(void\(\s*\*\s*\)\(Node\s*\*\s*\)\)\s*&\s*Node\s*::\s*"
+        r"(release_forward_liveness|release_backward_liveness|release_pending_liveness|"
+        r"own_forward_liveness|own_backward_liveness|own_pending_liveness)"
+    )
+    patched = pattern.sub(
+        lambda m: _WINDOWS_NODE_CALLBACK_WRAPPERS[m.group(1)],
+        source,
+    )
+    if patched == source:
+        return source
+
+    anchor = "static vector < pair < Node * , void( * )(Node * ) >>"
+    insert_at = patched.find(anchor)
+    if insert_at < 0:
+        namespace_match = re.search(r"\bnamespace\s+jittor\s*\{", patched)
+        if namespace_match is None:
+            return patched
+        insert_at = namespace_match.end()
+    return patched[:insert_at] + wrappers + patched[insert_at:]
+
+
+def prepare_windows_source(source: str) -> str:
+    return patch_windows_source(decode_source(source))


### PR DESCRIPTION
## Description / 描述
Fix Windows MSVC import failure when Jittor builds packed `data.gz` by preprocessing the packed source on Windows and replacing invalid `Node` member-function callback casts with free-function wrappers.

## Related Issue / 关联 Issue


## Type of Change / 修改类型
- [x] Bug fix / Bug 修复
- [x] Test addition / 添加测试

## Changes Summary / 修改摘要
- Add a Windows-only packed-data preprocessing path for MSVC.
- Replace invalid `Node` member-function pointer casts with wrapper callbacks.
- Add a regression test for the Windows packed-data transformation.

## Testing / 测试
- [x] I have added new tests for my changes.
- [ ] I have run the existing test suite (`python -m jittor.test -v`) and all tests pass.
- [ ] I have tested with CUDA enabled (if applicable).

## Checklist / 检查清单
- [x] My code follows the project's code style guidelines.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation accordingly.
- [x] My changes do not introduce new warnings or errors.
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.

## Breaking Changes / 破坏性变更
No / 无
