### PR TITLE
fix: expose Var.shape as a property in stubs

### DIFF
--- a/python/jittor/__init__.pyi
+++ b/python/jittor/__init__.pyi
@@ -7754,6 +7754,7 @@ class Var:
 		     * return True if the Var requires gradient calculation.
 		     * @see is_stop_grad'''
 		...
+	@property
 	def shape(self)-> Tuple[int]:		
 		'''Document:
 		* 

--- a/python/jittor/test/test_type_stub.py
+++ b/python/jittor/test/test_type_stub.py
@@ -1,0 +1,14 @@
+import re
+import unittest
+from pathlib import Path
+
+
+class TestTypeStub(unittest.TestCase):
+    def test_var_shape_is_property(self):
+        stub_path = Path(__file__).resolve().parents[1] / "__init__.pyi"
+        content = stub_path.read_text(encoding="utf8")
+        self.assertRegex(content, r"@property\s+def shape\(self\)-> Tuple\[int\]:")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/jittor/utils/gen_pyi.py
+++ b/python/jittor/utils/gen_pyi.py
@@ -154,6 +154,17 @@ def gen_ops_stub(jittor_path):
             hint += f" ...\n"
         return hint
 
+    def generate_var_property_hint(return_type, docstring):
+        hint = "\t@property\n"
+        hint += f"\tdef {func_name}(self)"
+        hint += f"-> {return_type}" if return_type else ""
+        hint += ":"
+        if docstring:
+            hint += add_indent(f"\n'''{docstring}'''\n", 2) + "\t\t...\n"
+        else:
+            hint += " ...\n"
+        return hint
+
     for func_name, func in jittor.ops.__dict__.items():
         if func_name.startswith("__"):
             continue
@@ -210,6 +221,10 @@ def gen_ops_stub(jittor_path):
         docstring = func.__doc__[:func.__doc__.find("Declaration:")]
         docstring = docstring.replace("'''", '"""').strip()
         declarations = re.findall(r"Declaration:\n(.+)\n", func.__doc__)
+
+        if func_name == "shape":
+            var_hint += generate_var_property_hint("Tuple[int]", docstring)
+            continue
 
         for decl in declarations:
             decl = decl.replace("inline ", "")


### PR DESCRIPTION
## Description / 描述
Fix the checked-in type stubs so `jt.Var.shape` is exposed as a property instead of a callable method, and keep the generator aligned with that behavior.

## Related Issue / 关联 Issue
Fixes #656

## Type of Change / 修改类型
- [x] Bug fix / Bug 修复
- [x] Test addition / 添加测试

## Changes Summary / 修改摘要
- Update `python/jittor/__init__.pyi` to expose `Var.shape` as a property.
- Update `python/jittor/utils/gen_pyi.py` so future stub regeneration preserves the property form.
- Add a static stub regression test in `python/jittor/test/test_type_stub.py`.

## Testing / 测试
- [ ] I have run the existing test suite (`python -m jittor.test -v`) and all tests pass.
- [x] I have added new tests for my changes.
- [ ] I have tested with CUDA enabled (if applicable).

## Checklist / 检查清单
- [x] My code follows the project's code style guidelines.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation accordingly.
- [x] My changes do not introduce new warnings or errors.
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.

## Breaking Changes / 破坏性变更
No / 无

## Additional Notes / 补充说明
- Verified by the new static stub regression test for `Var.shape`.
- This PR updates only type stubs and stub generation logic; no runtime behavior is changed.