### PR TITLE
Fix missing #include <array> in cuFFT operator causing compile error on GCC 12

### DIFF
--- a/python/jittor/extern/cuda/cufft/ops/cufft_fft_op.cc
+++ b/python/jittor/extern/cuda/cufft/ops/cufft_fft_op.cc
@@ -16,6 +16,7 @@
 #include "cufft_fft_op.h"
 #include "cufft_wrapper.h"
 
+#include <array>
 #include <complex>
 #include <iostream>
 #include <random>


### PR DESCRIPTION
## 描述

在jittor/extern/cuda/cufft/ops/cufft_fft_op.cc 文件中加上了对<array>的引用

## 修改类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Performance improvement / 性能优化
- [ ] Documentation update / 文档更新
- [ ] Test addition / 添加测试
- [ ] Refactoring (no functional changes) / 重构（无功能性变更）
- [ ] Other (please describe) / 其他（请描述）

## 修改摘要

### 修改动机

执行下述代码：

```python
import jittor as jt
import jittor.nn as nn
jt.flags.use_cuda = 1
real = jt.randn((1, 8, 8))
z = nn.ComplexNumber(real)
y = z.fft2()
print(y.real.sync())
```

遇到报错：

```text
/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/jit/cufft_fft__T_float32__I_0__TS__float32___JIT_1__JIT_cuda_1__index_t_int32_hash_233fd1e2f76a4366_op.cc(46): error: incomplete type is not allowed
      std::array<int, 2> fft = {n1, n2};
                         ^

1 error detected in the compilation of "/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/jit/cufft_fft__T_float32__I_0__TS__float32___JIT_1__JIT_cuda_1__index_t_int32_hash_233fd1e2f76a4366_op.cc".
Traceback (most recent call last):
  File "/home/A/COD/Jittor-DepthSAM/tests/test_fft.py", line 16, in <module>
    print(y.real.sync())
RuntimeError: Wrong inputs arguments, Please refer to examples(help(jt.sync)).

Types of your inputs are:
 self   = Var,
 args   = (),

The function declarations are:
 VarHolder* sync(bool device_sync = false, bool weak_sync = true)

Failed reason:[f 0624 22:45:59.094284 16 parallel_compiler.cc:331] Error happend during compilation:
 [Error] source file location:/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/jit/cufft_fft__T_float32__I_0__TS__float32___JIT_1__JIT_cuda_1__index_t_int32_hash_233fd1e2f76a4366_op.cc
Compile operator(5/7)failed:Op(25:1:1:1:i1:o1:s0:g1,cufft_fft->26)

Reason: [f 0624 22:45:56.885674 68:C5 log.cc:605] Check failed: ret>=0 && ret<=256  Run cmd failed: "/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/bin/nvcc" "/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/jit/cufft_fft__T_float32__I_0__TS__float32___JIT_1__JIT_cuda_1__index_t_int32_hash_233fd1e2f76a4366_op.cc"      -std=c++14 -Xcompiler -fPIC  -Xcompiler -march=native  -Xcompiler -fdiagnostics-color=always  -lstdc++ -ldl -shared  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/src"  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern" -I/home/A/miniconda3/envs/jittor_env/include/python3.9 -I/home/A/miniconda3/envs/jittor_env/include/python3.9 -DHAS_CUDA -DIS_CUDA -I"/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/include" -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/inc"  -lcudart -L"/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/lib64" -Xlinker -rpath="/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/lib64"  -I"/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86" -L"/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86" -Xlinker -rpath="/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86" -L"/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default" -Xlinker -rpath="/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default"  -l:"jit_utils_core.cpython-39-x86_64-linux-gnu".so  -l:"jittor_core.cpython-39-x86_64-linux-gnu".so  -x cu --cudart=shared -ccbin="/usr/bin/g++" --use_fast_math  -w  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/inc"  -arch=compute_86  -code=sm_86  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/cufft/inc"  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/cufft/ops"  -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/inc" -I"/home/A/miniconda3/envs/jittor_env/lib/python3.9/site-packages/jittor/extern/cuda/cufft/inc" -lcufft -L"/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/lib64" -Xlinker -rpath="/home/A/.cache/jittor/jtcuda/cuda12.2_cudnn8_linux/lib64"  -L"/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/cuda" -Xlinker -rpath="/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/cuda" -l:libcuda_extern.so   -L"/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/custom_ops" -Xlinker -rpath="/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/custom_ops" -l:"gen_ops_cufft_fft.cpython-39-x86_64-linux-gnu".so   -o "/home/A/.cache/jittor/jt1.3.10/g++12.4.0/py3.9.25/Linux-6.6.87.2x0c/12thGenIntelRCx5f/905c/default/cu12.2.140_sm_86/jit/cufft_fft__T_float32__I_0__TS__float32___JIT_1__JIT_cuda_1__index_t_int32_hash_233fd1e2f76a4366_op.so"
return 512. This might be an overcommit issue or out of memory. Try : sudo sysctl vm.overcommit_memory=1, or set enviroment variable `export DISABLE_MULTIPROCESSING=1`
```

### 运行环境

我使用运行在wsl上的`Ubuntu 24.04.4 LTS`，其余环境如下：
```text
Jittor 1.3.10.0
Python 3.9
g++ 12.4.0
Jittor CUDA 12.2
NVIDIA Driver CUDA 12.9
RTX 3050 Ti
```

### 修改理由

Jittor的复数FFT调用路径为：

```text
nn.ComplexNumber.fft2()
  -> nn._fft2(self.value, inverse=False)
  -> Jittor 生成 cufft_fft CUDA/C++ op
```

其中`ComplexNumber`将复数保存为：

```text
[B, H, W, 2]
```

最后一维`2`分别表示实部和虚部。Jittor 生成的 cuFFT op 源码内部使用了：

```cpp
std::array<int, 2> fft = {n1, n2};
```

但生成文件或其模板没有正确包含`#include <array>`。在当前环境组合下`std::array`没有被其他头文件间接引入，因此编译器认为它是不完整类型，导致JIT编译失败。因此本PR建议加上引用，以避免问题。修改后重新运行问题代码，输出符合预期。

> 顺便希望后续更新可以加上Var对象能直接调用的fft方法（如果从设计上不能增加原生复数dtype，或许可以考虑加一个`Var.fft2()`的语法糖？例如下面这样的）
> ```python
>  def fft2(self) -> nn.ComplexNumber:
>      cplx = nn.ComplexNumber(self, jt.zeros_like(self))
>      return cplx.fft2()
> ```

## 破坏性变更
无

## 补充说明
无


