### PR TITLE
fix(acl): keep FP32 precision in matmul/bmm (cubeMathType 1 -> 0)

### DIFF
--- a/python/jittor/extern/acl/aclops/bmm_op_acl.cc
+++ b/python/jittor/extern/acl/aclops/bmm_op_acl.cc
@@ -64,7 +64,7 @@ namespace jittor
     void BatchMatMulOpRunner::executeOp(std::unordered_map<string, AclOpFunctions>::iterator &it)
     {
 
-        ret = aclnnBatchMatMulGetWorkspaceSize(inputTensors[0], inputTensors[1], outputTensors[0], 1, &workspaceSize, &executor);
+        ret = aclnnBatchMatMulGetWorkspaceSize(inputTensors[0], inputTensors[1], outputTensors[0], 0, &workspaceSize, &executor);
         CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("%s: aclnnBatchMatmulGetWorkspaceSize failed. ERROR: %d\n", name.c_str(), ret); return);
         if (workspaceSize > 0)
         {

--- a/python/jittor/extern/acl/aclops/matmul_op_acl.cc
+++ b/python/jittor/extern/acl/aclops/matmul_op_acl.cc
@@ -64,7 +64,7 @@ namespace jittor
     void MatMulOpRunner::executeOp(std::unordered_map<string, AclOpFunctions>::iterator &it)
     {
 
-        ret = aclnnMatmulGetWorkspaceSize(inputTensors[0], inputTensors[1], outputTensors[0], 1, &workspaceSize, &executor);
+        ret = aclnnMatmulGetWorkspaceSize(inputTensors[0], inputTensors[1], outputTensors[0], 0, &workspaceSize, &executor);
         CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("%s: aclnnMatmulGetWorkspaceSize failed. ERROR: %d\n", name.c_str(), ret); return);
         if (workspaceSize > 0)
         {


### PR DESCRIPTION
Title / 标题:

    fix(acl): keep FP32 precision in matmul/bmm on Ascend (cubeMathType 1 -> 0)

---

## Description / 描述

`aclnnMatmul` and `aclnnBatchMatMul` were invoked with `cubeMathType = 1`
(`ALLOW_FP32_DOWN_PRECISION`), which allows the Ascend Cube unit to compute FP32
inputs in reduced precision (HF32/FP16). As a result, every `jt.matmul` / `jt.bmm` /
`nn.Linear` on Ascend silently lost about half of the FP32 mantissa.

Measured against a float64 reference (effective mantissa bits, higher is better):

| op | CPU | ACL before | ACL after |
|---|---|---|---|
| `matmul` 2D 64x64 | 23.0 bit | 12.7 bit | 23.9 bit |
| `nn.Linear` 200x64 | 23.0 bit | 12.7 bit | 23.9 bit |
| `bmm` 3D | 23.5 bit | 12.7 bit | 24.4 bit |
| `matmul` 4D (attention scores) | 23.5 bit | 12.8 bit | 24.4 bit |

Element-wise / reduction ops (`exp`, `erf`, `sigmoid`, `softmax`, `LayerNorm`,
reductions) were already at 24-26 bits, so the loss was specific to the Cube path.

The injected noise (~1e-3 relative error, ~1000x larger than the CPU backend) is
large enough to perturb training of matmul-dominated models. On a temporal
link-prediction model (CRAFT) it pushed validation AP/AUC away from the CUDA
reference and left the run prone to diverging to NaN after a few epochs.

This PR passes `0` (`KEEP_DTYPE`) instead, so FP32 inputs are computed in FP32.
`conv_op_acl.cc` already passes `0`, so this also makes the Cube ops consistent
with each other.

`aclnnMatmul` 和 `aclnnBatchMatMul` 之前传入的 `cubeMathType = 1`
（`ALLOW_FP32_DOWN_PRECISION`）允许 Cube 单元以降精度（HF32/FP16）计算 FP32 输入，
导致 Ascend 上所有 `matmul` / `bmm` / `nn.Linear` 的有效尾数位从约 23 bit 降到约 12.7 bit，
相对误差比 CPU 后端大约 1000 倍；而逐元素算子本身精度正常，说明问题只出在 Cube 路径。
本 PR 改为传 `0`（`KEEP_DTYPE`），使 FP32 输入以 FP32 计算，并与已经传 `0` 的
`conv_op_acl.cc` 保持一致。

## Related Issue / 关联 Issue

N/A — no existing issue for this; the problem was found while debugging a training
accuracy mismatch between the Ascend and CUDA backends. Happy to open a bug report
first if maintainers prefer to track it that way.

无对应 Issue（在排查 Ascend 与 CUDA 后端训练精度不一致时发现）。如维护者希望先建 Issue 跟踪，我可以补充。

## Type of Change / 修改类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Performance improvement / 性能优化
- [ ] Documentation update / 文档更新
- [ ] Test addition / 添加测试
- [ ] Refactoring (no functional changes) / 重构（无功能性变更）
- [ ] Other (please describe) / 其他（请描述）

## Changes Summary / 修改摘要

- `python/jittor/extern/acl/aclops/matmul_op_acl.cc`: `aclnnMatmulGetWorkspaceSize`
  now receives `cubeMathType = 0` (`KEEP_DTYPE`) instead of `1`
  (`ALLOW_FP32_DOWN_PRECISION`).
- `python/jittor/extern/acl/aclops/bmm_op_acl.cc`: same change for
  `aclnnBatchMatMulGetWorkspaceSize`.
- Cube-based ACL ops are now consistent: `conv_op_acl.cc` already used `0`, so
  matmul/bmm no longer behave differently from convolution w.r.t. FP32 precision.
- Single commit, 2 files changed, 2 insertions(+), 2 deletions(-); no API, flag or
  behaviour change outside the ACL backend.

## Testing / 测试

Environment: Ascend NPU (ACL backend, `jt.flags.use_acl = 1`), FP32.

- Existing ACL test suites pass: `python -m jittor.test.test_acl` and
  `python -m jittor.test.test_aclop` (including `test_matmul_1..6`,
  `test_matmul_grad_*`, `test_bmm_matmul`, `test_bmm_transpose`, `test_bmm_grad_*`).
- Precision check against a float64 reference: effective mantissa of
  `matmul` / `bmm` / `nn.Linear` goes from ~12.7 bit back to ~23.9-24.4 bit
  (table in the description above), matching the CPU backend.
- End-to-end check: a full forward + backward pass of a matmul-dominated model
  (CRAFT, temporal link prediction) now matches a CPU run to ~1e-6 (FP32 rounding)
  on every intermediate tensor and every parameter gradient, over several batches
  including all-padding edge cases. Before the fix the same comparison was off by
  ~1e-3 and the training run could diverge to NaN.
- Throughput: unaffected for the shapes used by that model — validation over 783
  batches went 31s -> 30s.

测试环境为 Ascend NPU（ACL 后端，FP32）：现有 `test_acl` / `test_aclop` 中的 matmul、bmm
及其反向测试全部通过；以 float64 为基准的精度测量显示有效尾数位从约 12.7 bit 恢复到约 24 bit；
matmul 密集模型的完整前向+反向与 CPU 结果在 1e-6 量级一致；小矩阵场景吞吐无回退。

- [x] I have run the existing test suite (`python -m jittor.test -v`) and all tests pass.
      我已运行现有测试套件且所有测试通过。
      Note: I ran the ACL-related tests (`test_acl`, `test_aclop`) on Ascend hardware. This change only affects the ACL backend. / 说明：仅在 Ascend 上运行了 ACL 相关测试，且本改动只影响 ACL 后端。
- [ ] I have added new tests for my changes.
      我已为修改添加了新测试。
- [ ] I have tested with CUDA enabled (if applicable).
      我已在启用 CUDA 的环境下测试（如适用）。
      Not applicable: the change is confined to the ACL (Ascend) backend and does not
      touch CUDA code. / 不适用：改动仅限 ACL（昇腾）后端，不涉及 CUDA 代码。

## Checklist / 检查清单

- [x] My code follows the project's code style guidelines.
      我的代码遵循项目的代码风格指南。
- [x] I have commented my code where necessary.
      我已在必要处添加了代码注释。
      (No new comment needed — the change only replaces a magic constant; the
      rationale is documented in the commit message.)
- [x] I have updated the documentation accordingly.
      我已相应地更新了文档。
      (No user-facing documentation describes `cubeMathType`, so no doc change is
      required.)
- [x] My changes do not introduce new warnings or errors.
      我的修改没有引入新的警告或错误。
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
      我已阅读[贡献指南](../CONTRIBUTING.md)。

## Breaking Changes / 破坏性变更

No / 无

The public API is unchanged. The only user-visible difference is that FP32
`matmul` / `bmm` / `nn.Linear` results on Ascend become more accurate, so numeric
outputs will differ slightly from previous releases (in the direction of the CPU and
CUDA backends).

公开 API 不变。唯一用户可见的变化是 Ascend 上 FP32 的 `matmul` / `bmm` / `nn.Linear`
结果更精确，因此数值与旧版本会有细微差异（更接近 CPU / CUDA 后端）。

## Additional Notes / 补充说明

- Performance trade-off: `KEEP_DTYPE` disables the HF32 fast path, so very large FP32
  GEMMs may become slower than before. In my measurements (small/medium matrices) the
  cost was not observable (783 validation batches: 31s -> 30s). I chose correctness by
  default, consistent with `conv_op_acl.cc`. If maintainers prefer to keep the fast
  path available, I can follow up with a flag/env switch (e.g.
  `jt.flags.acl_allow_fp32_down_precision`) that selects `cubeMathType` at runtime,
  defaulting to `KEEP_DTYPE`.
- FP16/BF16 inputs are unaffected: `cubeMathType` only controls how FP32 inputs are
  handled by the Cube unit.
- This PR contains a single commit: `fix(acl): keep FP32 precision in matmul/bmm
  (cubeMathType 1 -> 0)`.

性能取舍：`KEEP_DTYPE` 会关闭 HF32 快速路径，超大 FP32 GEMM 可能变慢；在实测的中小矩阵场景下
无可观测开销，因此默认选择正确性（与 `conv_op_acl.cc` 一致）。若维护者希望保留快速路径，
我可以后续提供一个运行时开关（默认 `KEEP_DTYPE`）。FP16/BF16 输入不受影响。本 PR 仅含一个 commit。
