### PR TITLE
fix(jtune): pass cmd as a keyword so the unknown-command assert renders

### DIFF
--- a/python/jittor/utils/jtune.py
+++ b/python/jittor/utils/jtune.py
@@ -58,4 +58,4 @@ elif cmd == "vtune_so":
     vtune_cmd = "amplxe-cl -collect uarch-exploration -r ./__res "+__file__+" "+lib_path+" run_so"
     run_cmd(vtune_cmd)
 else:
-    assert 0, "unknown cmd: {cmd}".format(cmd)
+    assert 0, "unknown cmd: {cmd}".format(cmd=cmd)


### PR DESCRIPTION
### The bug

`python/jittor/utils/jtune.py` takes the sub-command from `sys.argv[2]` and
dispatches on it. The final `else` is meant to tell the user what they typed:

```python
else:
    assert 0, "unknown cmd: {cmd}".format(cmd)
```

`{cmd}` is a **named** replacement field, but `cmd` is handed to `format()`
**positionally**. `str.format` therefore raises `KeyError: 'cmd'` while it is
still building the assert message — the `AssertionError` is never reached.

### Effect

```console
$ python3 -m jittor.utils.jtune /path/to/lib.so vtune_s
Traceback (most recent call last):
  File ".../jtune.py", line 61, in <module>
    assert 0, "unknown cmd: {cmd}".format(cmd)
                                   ^^^^^^^^^^^
KeyError: 'cmd'
```

Instead of the intended `AssertionError: unknown cmd: vtune_s`. Any typo in
the sub-command (`run_so`, `cc_to_so`, `perf_so`, `vtune_so`) lands here, so
this is the tool's own usage-error path.

### Before / after

| | message the user sees |
|---|---|
| before | `KeyError: 'cmd'` (raised while building the assert message) |
| after | `AssertionError: unknown cmd: vtune_s` |

`pyflakes` flags both halves of the mismatch on that line:

```
jtune.py:61:15: '...'.format(...) has unused arguments at position(s): 0
jtune.py:61:15: '...'.format(...) is missing argument(s) for placeholder(s): cmd
```

### The fix

`.format(cmd)` → `.format(cmd=cmd)`. One line, message text unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
