### PR TITLE
修复getitem的合并轴步长寻址

### DIFF
--- a/src/ops/composite/getitem_op.cc
+++ b/src/ops/composite/getitem_op.cc
@@ -222,8 +222,10 @@ void GetitemOp::infer_shape() {
         auto& oid = i_to_o[i];
         auto os = out_shape[oid];
         if (oid>=0) {
-            if (vid==-1 && i && i_to_vs[i-1]<0) {
-                vid = -2;
+            if (vid==-1 && i && i_to_vs[i-1]<0 &&
+                in->storage_stride(i-1) == in_shape[i] * in->storage_stride(i)) {
+                i_to_vs[i-1] = -2;
+                vid = -1;
                 o_shape.back() *= os;
             } else
                 o_shape.push_back(os);

--- a/tests/core/test_storage_strides.py
+++ b/tests/core/test_storage_strides.py
@@ -99,3 +99,19 @@ def test_positive_step_slice_has_storage_offset_and_strides():
     assert v._storage_address == a._storage_address + 4
     np.testing.assert_array_equal(v.numpy(), [1, 3, 5, 7])
     np.testing.assert_array_equal((v*2).numpy(), [2, 6, 10, 14])
+
+def test_split_last_axis_preserves_multidimensional_prefix():
+    values = np.arange(2 * 8 * 192, dtype=np.float32).reshape(2, 8, 192)
+    dense = jt.array(values) * 0.5 + 3
+    strided = jt.array(values.transpose(0, 2, 1)).transpose(1, 2)
+    assert list(strided._storage_strides()) == [1536, 1, 8]
+
+    for source, expected_source in (
+        (dense, values * 0.5 + 3),
+        (strided, values),
+    ):
+        parts = source.split(64, dim=2)
+        expected_parts = np.split(expected_source, [64, 128], axis=2)
+        assert [tuple(part.shape) for part in parts] == [(2, 8, 64)] * 3
+        for part, expected in zip(parts, expected_parts):
+            np.testing.assert_array_equal(part.numpy(), expected)


### PR DESCRIPTION
## Description / 描述

This PR fixes an incorrect stride/address calculation in the `getitem` multi-output optimization introduced with the storage-stride changes in Jittor 2.0.

When loop axes are merged during `getitem`, the previous implementation may continue to use the original physical stride even when the merged axes are not physically contiguous. This can result in incorrect memory addressing and silently produce wrong tensor values.

The issue can be reproduced by splitting a multi-dimensional tensor along a trailing dimension, for example:

```python
x.shape == [2, 8, 192]
x.split(64, dim=2)
```

This pattern is also used by fused QKV projections in models such as GPT-2. The PyTorch compatibility shim exposes the issue through `Tensor.split`, but the root cause is in Jittor core rather than the shim.

This PR applies a minimal fix in `getitem`: loop axes are merged only when their physical layout is contiguous, and the flattened index is associated with the innermost axis of the merged group.

## Related Issue / 关联 Issue

N/A

## Type of Change / 修改类型

* [x] Bug fix / Bug 修复
* [ ] New feature / 新功能
* [ ] Performance improvement / 性能优化
* [ ] Documentation update / 文档更新
* [x] Test addition / 添加测试
* [ ] Refactoring (no functional changes) / 重构（无功能性变更）
* [ ] Other (please describe) / 其他（请描述）

## Changes Summary / 修改摘要

* Fix stride/address calculation when `getitem` merges loop axes with non-contiguous physical strides.
* Preserve the existing optimization for physically contiguous layouts instead of disabling the multi-output `getitem` optimization globally.
* Add a regression test covering trailing-dimension `split`, including the `[2, 8, 192] -> 3 x [2, 8, 64]` case that reproduces the issue.

## Testing / 测试

Targeted regression and existing split/chunk tests were run successfully:

```text
8 passed
```

The tests cover:

* the new `getitem/split` regression case;
* existing `chunk/split` forward behavior;
* `split` backward behavior.

The fix was also validated using a HuggingFace GPT-2 parity test through the PyTorch compatibility layer:

```text
forward max_rel:        2.45e-7
worst gradient max_rel: 6.52e-7
matched gradients:      28/28
Jittor fallback count:  0
```

Before the fix, the minimal regression case produced incorrect values for 960 out of 1024 elements.

CUDA-specific execution was not tested because the local test environment does not have an NVIDIA GPU.

The broader structural test suite was also executed. On the current `2.0-refactor` baseline it reports:

```text
1235 passed
79 failed
```

The remaining failures are pre-existing/environment-related failures, mainly involving ACL mocks, documentation/dashboard contracts, and environment gates, and are unrelated to this change.

* [ ] I have run the existing test suite (`python -m jittor.test -v`) and all tests pass.
  我已运行现有测试套件且所有测试通过。
* [x] I have added new tests for my changes.
  我已为修改添加了新测试。
* [ ] I have tested with CUDA enabled (if applicable).
  我已在启用 CUDA 的环境下测试（如适用）。

## Checklist / 检查清单

* [x] My code follows the project's code style guidelines.
  我的代码遵循项目的代码风格指南。
* [x] I have commented my code where necessary.
  我已在必要处添加了代码注释。
* [ ] I have updated the documentation accordingly.
  我已相应地更新了文档。
* [x] My changes do not introduce new warnings or errors.
  我的修改没有引入新的警告或错误。
* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
  我已阅读[贡献指南](../CONTRIBUTING.md)。

## Breaking Changes / 破坏性变更

No / 无

## Additional Notes / 补充说明

The bug was initially exposed while running HuggingFace GPT-2 through Jittor's PyTorch compatibility layer. The compatibility shim itself does not require a workaround: `Tensor.split` correctly reaches Jittor's native `Var.split`, and the incorrect result originates from the underlying `getitem` stride handling.

The fix is intentionally kept in Jittor core so that native Jittor programs using the same tensor access pattern are fixed as well.
